### PR TITLE
feat: add Docker support, unit tests, and updated README

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+node_modules
+dist
+coverage
+*.md
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# ─── Stage 1: Build ──────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Install dependencies first (layer-cache friendly)
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy source and build
+COPY . .
+RUN npm run build
+
+# ─── Stage 2: Serve ──────────────────────────────────────────────────────────
+FROM nginx:1.27-alpine AS runtime
+
+# Remove default nginx static assets
+RUN rm -rf /usr/share/nginx/html/*
+
+# Copy built SPA
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# nginx config: serve SPA, forward unknown paths to index.html (client-side routing)
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,73 +1,228 @@
-# React + TypeScript + Vite
+# CCSDS TM Frame Transmitter
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A browser-based tool for constructing and transmitting **CCSDS TM (Telemetry) Transfer Frames** over WebSocket.
+Built with React + TypeScript + Vite. Reference standard: [CCSDS 132.0-B-3](https://public.ccsds.org/Pubs/132x0b3.pdf).
 
-Currently, two official plugins are available:
+---
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## What Was Built
 
-## React Compiler
+### Core Application
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+| Module | Description |
+|--------|-------------|
+| `src/utils/frameBuilder.ts` | Constructs complete CCSDS TM Transfer Frames per CCSDS 132.0-B-3. Handles the 6-byte primary header, optional secondary header, data field with idle-fill, OCF, and FECF. |
+| `src/utils/crc.ts` | CRC-16/CCITT-FALSE implementation (init 0xFFFF, poly 0x1021, no reflection) used for the Frame Error Control Field. |
+| `src/utils/hex.ts` | Hex/ASCII conversion utilities: parsing, formatting, hex-dump, and input validation. |
+| `src/hooks/useTransmitter.ts` | React hook that manages a WebSocket connection and fires frames at a configurable interval. Tracks MCFC/VCFC counters with 8-bit wrap-around. |
+| `src/components/FrameConfig.tsx` | Panel for all primary-header parameters: SCID, VCID, frame length, sync flag, FHP, and optional fields. |
+| `src/components/PayloadInput.tsx` | Hex / ASCII payload editor with file-upload, capacity bar, and helper fill buttons (idle, ramp). |
+| `src/components/TransmissionPanel.tsx` | WebSocket URL, interval control, start/stop, and live transmission statistics. |
+| `src/components/FramePreview.tsx` | Live colour-coded hex dump with section legend (Primary Header, Secondary Header, Data Field, OCF, FECF). |
 
-## Expanding the ESLint configuration
+### Frame Structure
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```
+┌────────────────────┬──────────────────────┬───────────────┬──────────┬──────────┐
+│  Primary Header    │  Secondary Header     │  Data Field   │  OCF     │  FECF    │
+│  6 bytes           │  1–64 bytes (opt)     │  variable     │  4 bytes │  2 bytes │
+│                    │                       │               │  (opt)   │  (opt)   │
+└────────────────────┴──────────────────────┴───────────────┴──────────┴──────────┘
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Total frame length: **7–2048 bytes**.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+### Unit Tests
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+74 tests across three test suites using **Vitest**:
+
+| Suite | Tests | Coverage |
+|-------|-------|----------|
+| `crc.test.ts` | 8 | CRC-16/CCITT-FALSE algorithm with known CCITT check vector (0x29B1) |
+| `hex.test.ts` | 33 | `hexToBytes`, `bytesToHex`, `byteHex`, `asciiToBytes`, `hexDump`, `validateHexInput` |
+| `frameBuilder.test.ts` | 33 | Frame construction, header encoding, optional fields, error cases, `availableDataBytes` |
+
+### Docker Support
+
+- **`Dockerfile`** — Multi-stage build: Node 22 builder → nginx 1.27 runtime. Final image is a minimal Alpine-based nginx container serving the pre-built SPA.
+- **`nginx.conf`** — Serves the SPA with a fallback to `index.html` for client-side routing and long-lived cache headers for static assets.
+- **`docker-compose.yml`** — Two services:
+  - `app` — the transmitter UI on port `8080`
+  - `ws-echo` — a lightweight WebSocket echo server on port `9000` for local testing
+
+---
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 18+
+- [Docker](https://www.docker.com/) (optional, for containerised deployment)
+
+---
+
+## Getting Started
+
+### Local development
+
+```bash
+# Install dependencies
+npm install
+
+# Start the dev server (hot-reload)
+npm run dev
 ```
+
+Open [http://localhost:5173](http://localhost:5173).
+
+### Run tests
+
+```bash
+# Run all tests once
+npm test
+
+# Watch mode (re-runs on file save)
+npm run test:watch
+
+# Generate HTML coverage report in ./coverage/
+npm run test:coverage
+```
+
+### Production build
+
+```bash
+npm run build
+# Built files are in dist/
+npm run preview   # preview the production build locally
+```
+
+---
+
+## Docker Deployment
+
+### Build and run with Docker Compose (recommended)
+
+```bash
+docker compose up --build
+```
+
+- Transmitter UI: [http://localhost:8080](http://localhost:8080)
+- WebSocket echo server: `ws://localhost:9000`
+
+To run only the transmitter UI (bring your own WebSocket receiver):
+
+```bash
+docker compose up --build app
+```
+
+### Build the image manually
+
+```bash
+docker build -t ccsds-tm-transmitter .
+docker run -p 8080:80 ccsds-tm-transmitter
+```
+
+---
+
+## User Guide
+
+### 1. Configure the Frame
+
+Use the **Frame Config** panel on the left to set:
+
+| Field | Description |
+|-------|-------------|
+| **SCID** | Spacecraft ID (0–1023, 10 bits) |
+| **VCID** | Virtual Channel ID (0–7, 3 bits) |
+| **Frame Length** | Total frame size in bytes (7–2048) |
+| **Sync Flag** | Set for byte-stream mode; clear for packet mode |
+| **Packet Order Flag** | Only meaningful when Sync Flag is 0 |
+| **Segment Length ID** | 0–3; `3` = unsegmented |
+| **First Header Pointer** | Offset of first packet header in data field; `0x7FF` = no packet, `0x7FE` = idle |
+| **Secondary Header** | Enable and paste hex data (1–63 bytes) |
+| **OCF** | Enable and enter 4-byte hex Operational Control Field |
+| **FECF** | Enable to append a CRC-16/CCITT-FALSE checksum |
+| **Idle Fill Byte** | Byte value used to pad unused data field space (default `0xE0`) |
+
+The **Available Payload** counter at the bottom of the panel shows how many bytes remain for user data given the current configuration.
+
+### 2. Enter Payload Data
+
+Use the **Payload** panel in the centre:
+
+- Toggle between **Hex** and **ASCII** input modes.
+- Type directly, or **drag-and-drop / browse** to upload a binary file.
+- Use the helper buttons:
+  - **Fill Idle** — fill the data field with the idle byte (`0xE0`)
+  - **Fill Ramp** — fill with a 0x00–0xFF ramp pattern
+  - **Clear** — clear the payload
+
+The capacity bar turns amber when over 75% full and red when the payload exceeds the available space (excess bytes are silently truncated to fit).
+
+### 3. Connect and Transmit
+
+Use the **Transmission** panel on the right:
+
+1. Enter the **WebSocket URL** (e.g. `ws://localhost:9000` or `ws://your-ground-station:4200`).
+2. Set the **interval** (100 ms – 10 s, or type a custom value).
+3. Click **Start** to begin transmitting.
+
+Live statistics update on every frame sent:
+
+| Stat | Description |
+|------|-------------|
+| **Frames Sent** | Total frame count since start |
+| **Bytes Sent** | Total bytes transmitted |
+| **MCFC** | Master Channel Frame Count (0–255, wraps) |
+| **VCFC** | Virtual Channel Frame Count (0–255, wraps) |
+
+Click **Stop** to halt transmission. The WebSocket connection is closed automatically.
+
+### 4. Inspect the Frame
+
+The **Frame Preview** at the bottom shows the currently assembled frame as a live hex dump.
+Each section is colour-coded:
+
+| Colour | Section |
+|--------|---------|
+| Blue | Primary Header |
+| Purple | Secondary Header |
+| Green | Data Field |
+| Amber | OCF |
+| Red | FECF |
+
+---
+
+## Project Structure
+
+```
+.
+├── Dockerfile
+├── docker-compose.yml
+├── nginx.conf
+├── index.html
+├── vite.config.ts
+├── package.json
+└── src/
+    ├── main.tsx
+    ├── App.tsx
+    ├── types.ts
+    ├── components/
+    │   ├── FrameConfig.tsx
+    │   ├── FramePreview.tsx
+    │   ├── PayloadInput.tsx
+    │   └── TransmissionPanel.tsx
+    ├── hooks/
+    │   └── useTransmitter.ts
+    └── utils/
+        ├── crc.ts
+        ├── crc.test.ts
+        ├── frameBuilder.ts
+        ├── frameBuilder.test.ts
+        ├── hex.ts
+        └── hex.test.ts
+```
+
+---
+
+## License
+
+MIT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:80"
+    restart: unless-stopped
+
+  # Optional WebSocket echo server – useful for local testing.
+  # Echoes every binary or text message back to the sender.
+  # Connect the transmitter to: ws://localhost:9000
+  ws-echo:
+    image: node:22-alpine
+    working_dir: /app
+    command: >
+      sh -c "npm install ws && node -e \"
+        const { WebSocketServer } = require('ws');
+        const wss = new WebSocketServer({ port: 9000 });
+        wss.on('connection', ws => {
+          console.log('client connected');
+          ws.on('message', msg => { console.log('rx', msg.length, 'bytes'); ws.send(msg); });
+          ws.on('close', () => console.log('client disconnected'));
+        });
+        console.log('WS echo listening on ws://0.0.0.0:9000');
+      \""
+    ports:
+      - "9000:9000"
+    restart: unless-stopped

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Serve static assets with long cache
+    location ~* \.(?:js|css|woff2?|svg|png|ico|webp)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Fall back to index.html for client-side routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
+        "@vitest/coverage-v8": "^4.0.18",
         "autoprefixer": "^10.4.24",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -26,7 +27,8 @@
         "tailwindcss": "^3.4.19",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -322,6 +324,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1420,6 +1432,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1464,6 +1483,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1812,6 +1849,148 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1915,6 +2094,35 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
+      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.24",
@@ -2084,6 +2292,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2264,6 +2482,13 @@
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2504,6 +2729,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2512,6 +2747,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2772,6 +3017,13 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2877,6 +3129,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "1.21.7",
@@ -3032,6 +3323,57 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3164,6 +3506,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3251,6 +3604,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3715,6 +4075,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3724,6 +4091,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3848,6 +4229,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3863,6 +4261,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -4079,6 +4487,84 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4093,6 +4579,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "react": "^19.2.0",
@@ -19,6 +22,7 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "@vitest/coverage-v8": "^4.0.18",
     "autoprefixer": "^10.4.24",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
@@ -28,6 +32,7 @@
     "tailwindcss": "^3.4.19",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/src/utils/crc.test.ts
+++ b/src/utils/crc.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { crc16ccitt } from './crc';
+
+describe('crc16ccitt', () => {
+  it('returns 0xFFFF for empty input', () => {
+    expect(crc16ccitt(new Uint8Array(0))).toBe(0xffff);
+  });
+
+  it('computes the standard CCITT check value for "123456789"', () => {
+    // CRC-16/CCITT-FALSE known vector: 0x29B1
+    const data = new Uint8Array([0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39]);
+    expect(crc16ccitt(data)).toBe(0x29b1);
+  });
+
+  it('returns a 16-bit value in range 0x0000–0xFFFF', () => {
+    const result = crc16ccitt(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(0xffff);
+    expect(result).toBe(0x4097);
+  });
+
+  it('produces different values for different inputs', () => {
+    const a = crc16ccitt(new Uint8Array([0x01]));
+    const b = crc16ccitt(new Uint8Array([0x02]));
+    expect(a).not.toBe(b);
+  });
+
+  it('produces consistent results for the same input', () => {
+    const data = new Uint8Array([0xca, 0xfe, 0xba, 0xbe]);
+    expect(crc16ccitt(data)).toBe(crc16ccitt(data));
+  });
+
+  it('is sensitive to byte order', () => {
+    const ab = crc16ccitt(new Uint8Array([0xab, 0xcd]));
+    const ba = crc16ccitt(new Uint8Array([0xcd, 0xab]));
+    expect(ab).not.toBe(ba);
+  });
+
+  it('computes correct CRC for a single 0x00 byte', () => {
+    expect(crc16ccitt(new Uint8Array([0x00]))).toBe(0xe1f0);
+  });
+
+  it('computes correct CRC for a single 0xFF byte', () => {
+    expect(crc16ccitt(new Uint8Array([0xff]))).toBe(0xff00);
+  });
+});

--- a/src/utils/frameBuilder.test.ts
+++ b/src/utils/frameBuilder.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect } from 'vitest';
+import { buildTMFrame, availableDataBytes, FHP_IDLE, FHP_NO_PACKET } from './frameBuilder';
+import type { FrameConfig } from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal valid FrameConfig – no optional fields. */
+function makeConfig(overrides: Partial<FrameConfig> = {}): FrameConfig {
+  return {
+    scid: 0,
+    vcid: 0,
+    hasOCF: false,
+    syncFlag: false,
+    packetOrderFlag: false,
+    segmentLengthId: 3,
+    firstHeaderPointer: FHP_NO_PACKET,
+    frameLength: 7,
+    hasSecondaryHeader: false,
+    secondaryHeaderData: '',
+    ocfData: '',
+    hasFECF: false,
+    idleFillByte: 0xe0,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildTMFrame – basic structure
+// ---------------------------------------------------------------------------
+
+describe('buildTMFrame – basic structure', () => {
+  it('builds a minimal 7-byte frame with correct header bytes', () => {
+    const cfg = makeConfig();
+    const { frame, error } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+
+    expect(error).toBeNull();
+    expect(frame.length).toBe(7);
+    // Primary header: word01 = 0x0000, mcfc=0x00, vcfc=0x00, word45=0x1FFF
+    expect(frame[0]).toBe(0x00);
+    expect(frame[1]).toBe(0x00);
+    expect(frame[2]).toBe(0x00); // MCFC
+    expect(frame[3]).toBe(0x00); // VCFC
+    expect(frame[4]).toBe(0x1f);
+    expect(frame[5]).toBe(0xff);
+    // Data field byte: idle fill
+    expect(frame[6]).toBe(0xe0);
+  });
+
+  it('encodes SCID and VCID in the primary header', () => {
+    const cfg = makeConfig({ scid: 42, vcid: 3, frameLength: 7 });
+    const { frame, error } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+
+    expect(error).toBeNull();
+    // word01 = (42 << 4) | (3 << 1) = 0x02A6
+    expect(frame[0]).toBe(0x02);
+    expect(frame[1]).toBe(0xa6);
+  });
+
+  it('encodes MCFC and VCFC counters', () => {
+    const cfg = makeConfig({ frameLength: 7 });
+    const { frame, error } = buildTMFrame(cfg, new Uint8Array(0), 200, 123);
+
+    expect(error).toBeNull();
+    expect(frame[2]).toBe(200); // MCFC
+    expect(frame[3]).toBe(123); // VCFC
+  });
+
+  it('wraps MCFC/VCFC at 255 (8-bit mask)', () => {
+    const cfg = makeConfig({ frameLength: 7 });
+    const { frame } = buildTMFrame(cfg, new Uint8Array(0), 256, 257);
+
+    expect(frame[2]).toBe(0); // 256 & 0xFF
+    expect(frame[3]).toBe(1); // 257 & 0xFF
+  });
+
+  it('fills data field with idle byte when payload is empty', () => {
+    const cfg = makeConfig({ frameLength: 10, idleFillByte: 0xaa });
+    const { frame, idleBytesUsed } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+
+    expect(idleBytesUsed).toBe(4); // 10 - 6 = 4 data bytes
+    for (let i = 6; i < 10; i++) {
+      expect(frame[i]).toBe(0xaa);
+    }
+  });
+
+  it('places payload at the start of the data field', () => {
+    const cfg = makeConfig({ frameLength: 10 });
+    const payload = new Uint8Array([0x01, 0x02, 0x03]);
+    const { frame, payloadBytesUsed, idleBytesUsed } = buildTMFrame(cfg, payload, 0, 0);
+
+    expect(payloadBytesUsed).toBe(3);
+    expect(idleBytesUsed).toBe(1);
+    expect(frame[6]).toBe(0x01);
+    expect(frame[7]).toBe(0x02);
+    expect(frame[8]).toBe(0x03);
+    expect(frame[9]).toBe(0xe0); // idle fill
+  });
+
+  it('truncates payload to fit the data field', () => {
+    const cfg = makeConfig({ frameLength: 8 }); // 2 data bytes
+    const payload = new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05]);
+    const { payloadBytesUsed, idleBytesUsed } = buildTMFrame(cfg, payload, 0, 0);
+
+    expect(payloadBytesUsed).toBe(2);
+    expect(idleBytesUsed).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTMFrame – validation errors
+// ---------------------------------------------------------------------------
+
+describe('buildTMFrame – validation errors', () => {
+  it('rejects a frame length below 7', () => {
+    const { error } = buildTMFrame(makeConfig({ frameLength: 6 }), new Uint8Array(0), 0, 0);
+    expect(error).not.toBeNull();
+    expect(error).toMatch(/7/);
+  });
+
+  it('rejects a frame length above 2048', () => {
+    const { error } = buildTMFrame(makeConfig({ frameLength: 2049 }), new Uint8Array(0), 0, 0);
+    expect(error).not.toBeNull();
+  });
+
+  it('rejects when options leave no room for the data field', () => {
+    // 7-byte frame + OCF(4) + FECF(2) → overhead=12, data=-5 → invalid
+    const cfg = makeConfig({ frameLength: 7, hasOCF: true, hasFECF: true });
+    const { error } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+    expect(error).not.toBeNull();
+    expect(error).toMatch(/too small/i);
+  });
+
+  it('rejects invalid secondary header hex data', () => {
+    const cfg = makeConfig({
+      frameLength: 20,
+      hasSecondaryHeader: true,
+      secondaryHeaderData: 'zzzz',
+    });
+    const { error } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+    expect(error).not.toBeNull();
+    expect(error).toMatch(/secondary header/i);
+  });
+
+  it('returns an error object and an empty frame on failure', () => {
+    const { frame, sections, error } = buildTMFrame(
+      makeConfig({ frameLength: 0 }),
+      new Uint8Array(0),
+      0,
+      0,
+    );
+    expect(error).not.toBeNull();
+    expect(frame.length).toBe(0);
+    expect(sections.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTMFrame – optional fields
+// ---------------------------------------------------------------------------
+
+describe('buildTMFrame – FECF', () => {
+  it('appends a 2-byte CRC when hasFECF is true', () => {
+    // frameLength=9: 6 header + 1 data + 2 FECF
+    const cfg = makeConfig({ frameLength: 9, hasFECF: true });
+    const { frame, error } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+
+    expect(error).toBeNull();
+    expect(frame.length).toBe(9);
+    // Pre-computed FECF for this frame: 0x604D
+    expect(frame[7]).toBe(0x60);
+    expect(frame[8]).toBe(0x4d);
+  });
+
+  it('includes a FECF section in the sections array', () => {
+    const cfg = makeConfig({ frameLength: 9, hasFECF: true });
+    const { sections } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+    const fecfSection = sections.find(s => s.label === 'FECF');
+    expect(fecfSection).toBeDefined();
+    expect(fecfSection!.end - fecfSection!.start).toBe(2);
+  });
+});
+
+describe('buildTMFrame – OCF', () => {
+  it('inserts a 4-byte OCF field before FECF', () => {
+    // frameLength=11: 6 header + 1 data + 4 OCF
+    const cfg = makeConfig({ frameLength: 11, hasOCF: true, ocfData: 'AABBCCDD' });
+    const { frame, error } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+
+    expect(error).toBeNull();
+    expect(frame.length).toBe(11);
+    expect(frame[7]).toBe(0xaa);
+    expect(frame[8]).toBe(0xbb);
+    expect(frame[9]).toBe(0xcc);
+    expect(frame[10]).toBe(0xdd);
+  });
+
+  it('sets the OCF flag bit in the primary header', () => {
+    const cfg = makeConfig({ frameLength: 11, hasOCF: true });
+    const { frame } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+    // Bit 0 of byte 1 is the OCF flag
+    expect(frame[1] & 0x01).toBe(1);
+  });
+
+  it('includes an OCF section in the sections array', () => {
+    const cfg = makeConfig({ frameLength: 11, hasOCF: true });
+    const { sections } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+    const ocfSection = sections.find(s => s.label === 'OCF');
+    expect(ocfSection).toBeDefined();
+    expect(ocfSection!.end - ocfSection!.start).toBe(4);
+  });
+});
+
+describe('buildTMFrame – Secondary Header', () => {
+  it('inserts a secondary header with the correct ID byte', () => {
+    // frameLength=12: 6 PH + (1 SH_ID + 4 SH_data) + 1 data
+    const cfg = makeConfig({
+      frameLength: 12,
+      hasSecondaryHeader: true,
+      secondaryHeaderData: 'AABBCCDD', // 4 bytes
+    });
+    const { frame, error } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+
+    expect(error).toBeNull();
+    // SH ID byte: bits [7:6]=00, bits [5:0]=data length (4)
+    expect(frame[6]).toBe(0x04);
+    // SH data bytes
+    expect(frame[7]).toBe(0xaa);
+    expect(frame[8]).toBe(0xbb);
+    expect(frame[9]).toBe(0xcc);
+    expect(frame[10]).toBe(0xdd);
+  });
+
+  it('sets the secondary header flag in the primary header', () => {
+    const cfg = makeConfig({
+      frameLength: 12,
+      hasSecondaryHeader: true,
+      secondaryHeaderData: 'AABBCCDD',
+    });
+    const { frame } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+    // Bit 15 of word45 (byte 4, bit 7)
+    expect(frame[4] & 0x80).toBe(0x80);
+  });
+
+  it('includes a Secondary Header section in sections array', () => {
+    const cfg = makeConfig({
+      frameLength: 12,
+      hasSecondaryHeader: true,
+      secondaryHeaderData: 'AABBCCDD',
+    });
+    const { sections } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+    const shSection = sections.find(s => s.label === 'Secondary Header');
+    expect(shSection).toBeDefined();
+    expect(shSection!.end - shSection!.start).toBe(5); // 1 ID + 4 data
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTMFrame – sections
+// ---------------------------------------------------------------------------
+
+describe('buildTMFrame – sections', () => {
+  it('always includes a Primary Header section spanning bytes 0–6', () => {
+    const { sections } = buildTMFrame(makeConfig({ frameLength: 7 }), new Uint8Array(0), 0, 0);
+    const ph = sections.find(s => s.label === 'Primary Header');
+    expect(ph).toBeDefined();
+    expect(ph!.start).toBe(0);
+    expect(ph!.end).toBe(6);
+  });
+
+  it('always includes a Data Field section', () => {
+    const { sections } = buildTMFrame(makeConfig({ frameLength: 10 }), new Uint8Array(0), 0, 0);
+    const df = sections.find(s => s.label === 'Data Field');
+    expect(df).toBeDefined();
+    expect(df!.end - df!.start).toBe(4); // 10 - 6
+  });
+
+  it('section boundaries are contiguous (no gaps or overlaps)', () => {
+    const cfg = makeConfig({
+      frameLength: 20,
+      hasOCF: true,
+      hasFECF: true,
+      hasSecondaryHeader: true,
+      secondaryHeaderData: 'AABB',
+    });
+    const { sections, frame } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+    expect(sections[0].start).toBe(0);
+    expect(sections[sections.length - 1].end).toBe(frame.length);
+    for (let i = 1; i < sections.length; i++) {
+      expect(sections[i].start).toBe(sections[i - 1].end);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTMFrame – FHP sentinel values
+// ---------------------------------------------------------------------------
+
+describe('buildTMFrame – FHP sentinel constants', () => {
+  it('FHP_IDLE is 0x7FE', () => {
+    expect(FHP_IDLE).toBe(0x7fe);
+  });
+
+  it('FHP_NO_PACKET is 0x7FF', () => {
+    expect(FHP_NO_PACKET).toBe(0x7ff);
+  });
+
+  it('encodes FHP_IDLE in the primary header', () => {
+    const cfg = makeConfig({ frameLength: 7, firstHeaderPointer: FHP_IDLE });
+    const { frame } = buildTMFrame(cfg, new Uint8Array(0), 0, 0);
+    // word45 bits [10:0] = FHP
+    const word45 = (frame[4] << 8) | frame[5];
+    expect(word45 & 0x7ff).toBe(FHP_IDLE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// availableDataBytes
+// ---------------------------------------------------------------------------
+
+describe('availableDataBytes', () => {
+  it('returns frameLength minus 6 with no optional fields', () => {
+    const cfg = makeConfig({ frameLength: 128 });
+    expect(availableDataBytes(cfg)).toBe(122);
+  });
+
+  it('subtracts 2 bytes for FECF', () => {
+    const cfg = makeConfig({ frameLength: 128, hasFECF: true });
+    expect(availableDataBytes(cfg)).toBe(120);
+  });
+
+  it('subtracts 4 bytes for OCF', () => {
+    const cfg = makeConfig({ frameLength: 128, hasOCF: true });
+    expect(availableDataBytes(cfg)).toBe(118);
+  });
+
+  it('subtracts 1 + SH data bytes for secondary header', () => {
+    // 4 hex bytes = 2 SH data bytes
+    const cfg = makeConfig({
+      frameLength: 128,
+      hasSecondaryHeader: true,
+      secondaryHeaderData: 'AABB', // 2 bytes
+    });
+    expect(availableDataBytes(cfg)).toBe(119); // 128 - 6 - 1 - 2
+  });
+
+  it('accounts for all optional fields combined', () => {
+    const cfg = makeConfig({
+      frameLength: 128,
+      hasFECF: true,
+      hasOCF: true,
+      hasSecondaryHeader: true,
+      secondaryHeaderData: 'AABBCCDD', // 4 bytes
+    });
+    expect(availableDataBytes(cfg)).toBe(111); // 128 - 6 - 2 - 4 - 1 - 4
+  });
+
+  it('returns 0 and does not go negative when frame is too small for options', () => {
+    const cfg = makeConfig({ frameLength: 7, hasFECF: true, hasOCF: true });
+    expect(availableDataBytes(cfg)).toBe(0);
+  });
+
+  it('caps secondary header data at 63 bytes', () => {
+    // 126 hex chars = 63 bytes (the maximum SH data length)
+    const cfg = makeConfig({
+      frameLength: 200,
+      hasSecondaryHeader: true,
+      secondaryHeaderData: 'AA'.repeat(64), // 64 bytes → capped to 63
+    });
+    expect(availableDataBytes(cfg)).toBe(200 - 6 - 1 - 63); // 130
+  });
+});

--- a/src/utils/hex.test.ts
+++ b/src/utils/hex.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hexToBytes,
+  bytesToHex,
+  byteHex,
+  asciiToBytes,
+  hexDump,
+  validateHexInput,
+} from './hex';
+
+// ---------------------------------------------------------------------------
+// hexToBytes
+// ---------------------------------------------------------------------------
+describe('hexToBytes', () => {
+  it('returns an empty Uint8Array for an empty string', () => {
+    const result = hexToBytes('');
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(0);
+  });
+
+  it('parses a plain hex string', () => {
+    const result = hexToBytes('deadbeef');
+    expect(result).toEqual(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+  });
+
+  it('parses uppercase hex', () => {
+    const result = hexToBytes('DEADBEEF');
+    expect(result).toEqual(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+  });
+
+  it('parses space-separated hex pairs', () => {
+    const result = hexToBytes('de ad be ef');
+    expect(result).toEqual(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+  });
+
+  it('parses colon-separated hex pairs', () => {
+    const result = hexToBytes('de:ad:be:ef');
+    expect(result).toEqual(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+  });
+
+  it('parses mixed separators', () => {
+    const result = hexToBytes('de ad:be ef');
+    expect(result).toEqual(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+  });
+
+  it('returns null for an odd number of hex digits', () => {
+    expect(hexToBytes('abc')).toBeNull();
+  });
+
+  it('returns null for invalid hex characters', () => {
+    expect(hexToBytes('zzzz')).toBeNull();
+  });
+
+  it('parses a single byte', () => {
+    expect(hexToBytes('ff')).toEqual(new Uint8Array([0xff]));
+  });
+
+  it('parses zeroes correctly', () => {
+    expect(hexToBytes('0000')).toEqual(new Uint8Array([0x00, 0x00]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bytesToHex
+// ---------------------------------------------------------------------------
+describe('bytesToHex', () => {
+  it('returns an empty string for empty input', () => {
+    expect(bytesToHex(new Uint8Array(0))).toBe('');
+  });
+
+  it('formats bytes as space-separated uppercase hex pairs', () => {
+    expect(bytesToHex(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))).toBe('DE AD BE EF');
+  });
+
+  it('pads single-digit values with a leading zero', () => {
+    expect(bytesToHex(new Uint8Array([0x0f, 0x01, 0x00]))).toBe('0F 01 00');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// byteHex
+// ---------------------------------------------------------------------------
+describe('byteHex', () => {
+  it('formats 0x00 as "00"', () => {
+    expect(byteHex(0x00)).toBe('00');
+  });
+
+  it('formats 0xff as "FF"', () => {
+    expect(byteHex(0xff)).toBe('FF');
+  });
+
+  it('formats 0x0a as "0A"', () => {
+    expect(byteHex(0x0a)).toBe('0A');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// asciiToBytes
+// ---------------------------------------------------------------------------
+describe('asciiToBytes', () => {
+  it('returns empty array for empty string', () => {
+    expect(asciiToBytes('')).toEqual(new Uint8Array(0));
+  });
+
+  it('converts ASCII text to byte values', () => {
+    expect(asciiToBytes('ABC')).toEqual(new Uint8Array([0x41, 0x42, 0x43]));
+  });
+
+  it('converts lowercase letters', () => {
+    expect(asciiToBytes('abc')).toEqual(new Uint8Array([0x61, 0x62, 0x63]));
+  });
+
+  it('truncates high bytes (mask 0xFF)', () => {
+    // charCode of regular chars will be ≤ 127, but the mask should not affect standard ASCII
+    const result = asciiToBytes('A');
+    expect(result[0]).toBe(0x41);
+  });
+
+  it('converts a space character', () => {
+    expect(asciiToBytes(' ')).toEqual(new Uint8Array([0x20]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hexDump
+// ---------------------------------------------------------------------------
+describe('hexDump', () => {
+  it('returns an empty array for empty input', () => {
+    expect(hexDump(new Uint8Array(0))).toEqual([]);
+  });
+
+  it('produces one row for ≤16 bytes', () => {
+    const rows = hexDump(new Uint8Array([0x01, 0x02, 0x03]));
+    expect(rows.length).toBe(1);
+    expect(rows[0]).toBe('01 02 03');
+  });
+
+  it('produces two rows for exactly 17 bytes', () => {
+    const data = new Uint8Array(17).fill(0xaa);
+    const rows = hexDump(data);
+    expect(rows.length).toBe(2);
+    expect(rows[0]).toBe('AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA');
+    expect(rows[1]).toBe('AA');
+  });
+
+  it('formats each byte as uppercase two-char hex', () => {
+    const rows = hexDump(new Uint8Array([0x0f, 0xf0]));
+    expect(rows[0]).toBe('0F F0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateHexInput
+// ---------------------------------------------------------------------------
+describe('validateHexInput', () => {
+  it('returns null for an empty string', () => {
+    expect(validateHexInput('')).toBeNull();
+  });
+
+  it('returns null for valid hex without separators', () => {
+    expect(validateHexInput('deadbeef')).toBeNull();
+  });
+
+  it('returns null for valid hex with spaces', () => {
+    expect(validateHexInput('de ad be ef')).toBeNull();
+  });
+
+  it('returns null for valid hex with colons', () => {
+    expect(validateHexInput('de:ad:be:ef')).toBeNull();
+  });
+
+  it('returns an error message for an odd number of digits', () => {
+    expect(validateHexInput('abc')).toBe('Odd number of hex digits');
+  });
+
+  it('returns an error message for invalid characters', () => {
+    expect(validateHexInput('zzzz')).toBe('Invalid hex characters');
+  });
+
+  it('returns null for "00" (valid single byte)', () => {
+    expect(validateHexInput('00')).toBeNull();
+  });
+
+  it('returns null for uppercase valid hex', () => {
+    expect(validateHexInput('AABBCCDD')).toBeNull();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,13 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/utils/**'],
+    },
+  },
 })


### PR DESCRIPTION
- Dockerfile: multi-stage build (Node 22 builder → nginx 1.27 alpine runtime)
- nginx.conf: SPA fallback routing with long-lived cache headers for assets
- docker-compose.yml: app service (port 8080) + ws-echo service (port 9000)
- .dockerignore: exclude node_modules, dist, .git from build context

Unit tests (Vitest, 74 tests across 3 suites):
- src/utils/crc.test.ts: CRC-16/CCITT-FALSE with known CCITT check vector
- src/utils/hex.test.ts: hexToBytes, bytesToHex, byteHex, asciiToBytes, hexDump, validateHexInput
- src/utils/frameBuilder.test.ts: frame construction, header bit encoding, optional fields (FECF/OCF/Secondary Header), error validation, availableDataBytes

package.json: added test, test:watch, test:coverage scripts
vite.config.ts: configured Vitest (node env, coverage via v8)
README.md: replaced Vite template with full project documentation and user guide

https://claude.ai/code/session_017XTD7sTB1Ajzf4AyvpFuQ6