### PR TITLE
fix: preserve 'error' wsStatus when WebSocket connection fails

### DIFF
--- a/src/hooks/useTransmitter.ts
+++ b/src/hooks/useTransmitter.ts
@@ -9,7 +9,7 @@ interface UseTransmitterReturn {
   lastFrame: Uint8Array | null;
   lastError: string | null;
   start: (frameConfig: FrameConfig, txConfig: TransmissionConfig, payload: Uint8Array) => void;
-  stop: () => void;
+  stop: (finalStatus?: WsStatus) => void;
   resetStats: () => void;
 }
 
@@ -53,12 +53,12 @@ export function useTransmitter(): UseTransmitterReturn {
     }
   }, []);
 
-  const stop = useCallback(() => {
+  const stop = useCallback((finalStatus: WsStatus = 'disconnected') => {
     runningRef.current = false;
     clearTimer();
     closeSocket();
     setIsRunning(false);
-    setWsStatus('disconnected');
+    setWsStatus(finalStatus);
   }, [clearTimer, closeSocket]);
 
   const start = useCallback(
@@ -137,9 +137,8 @@ export function useTransmitter(): UseTransmitterReturn {
 
       ws.onerror = () => {
         if (!runningRef.current) return;
-        setWsStatus('error');
         setLastError('WebSocket connection error');
-        stop();
+        stop('error');
       };
 
       ws.onclose = (ev) => {


### PR DESCRIPTION
stop() was unconditionally calling setWsStatus('disconnected'), which overwrote the 'error' status set by the onerror handler in the same React 18 render batch. The error state was therefore never rendered — the status dot stayed grey instead of turning red.

Fix: add an optional finalStatus parameter to stop() (default: 'disconnected'). The onerror handler now calls stop('error') as a single state flush, with no competing setWsStatus call to overwrite it.

https://claude.ai/code/session_017XTD7sTB1Ajzf4AyvpFuQ6