### PR TITLE
fix: separate Vitest config to fix Docker build failure

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,13 +4,4 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'html'],
-      include: ['src/utils/**'],
-    },
-  },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/utils/**'],
+    },
+  },
+})


### PR DESCRIPTION
The production build (tsc -b && vite build) was failing because vite's defineConfig type does not include the 'test' property. Switching the import to 'vitest/config' masked that error but broke resolution of 'vite/client' and '@types/node' in the tsc project references.

Fix: revert vite.config.ts to a plain Vite config and move all Vitest settings into a new vitest.config.ts. Vitest auto-discovers vitest.config.ts, so no changes to package.json scripts are needed. The production build now type-checks and bundles cleanly.

https://claude.ai/code/session_017XTD7sTB1Ajzf4AyvpFuQ6