### PR TITLE
feat: add CADU payload dependency selection (Transfer Frame, Reed-Sol…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ Built with React + TypeScript + Vite. Reference standards: [CCSDS 132.0-B-3](htt
 | Module | Description |
 |--------|-------------|
 | `src/utils/frameBuilder.ts` | Constructs complete CCSDS TM Transfer Frames per CCSDS 132.0-B-3. Handles the 6-byte primary header, optional secondary header, data field with idle-fill, OCF, and FECF. |
-| `src/utils/cadu.ts` | CADU encapsulation per CCSDS 131.0-B-5. Prepends the 4-byte ASM (`1A CF FC 1D`) and optionally applies PRBS pseudo-randomization (Fibonacci LFSR, h(x)=x⁸+x⁷+x⁵+x³+1, seed 0xFF). |
+| `src/utils/cadu.ts` | CADU encapsulation per CCSDS 131.0-B-5. Prepends the 4-byte ASM (`1A CF FC 1D`). Supports three payload types: Transfer Frame, Reed-Solomon coded, and raw Codeword. Optionally applies PRBS pseudo-randomization. |
+| `src/utils/reedSolomon.ts` | Reed-Solomon encoder per CCSDS 131.0-B-5 §4. GF(2⁸) with primitive polynomial 0x187. Supports RS(255,223) and RS(255,239) with interleave depths 1, 2, 3, 4, 5, 8. Includes syndrome validation. |
 | `src/utils/crc.ts` | CRC-16/CCITT-FALSE implementation (init 0xFFFF, poly 0x1021, no reflection) used for the Frame Error Control Field. |
 | `src/utils/hex.ts` | Hex/ASCII conversion utilities: parsing, formatting, hex-dump, and input validation. |
-| `src/hooks/useTransmitter.ts` | React hook that manages a WebSocket connection and fires frames at a configurable interval. Wraps the frame in a CADU when enabled. Tracks MCFC/VCFC counters with 8-bit wrap-around. |
-| `src/components/FrameConfig.tsx` | Panel for all primary-header parameters: SCID, VCID, frame length, sync flag, FHP, optional fields, and CADU encapsulation. |
+| `src/hooks/useTransmitter.ts` | React hook that manages a WebSocket connection and fires frames at a configurable interval. Wraps the frame in a CADU (with the selected payload type) when enabled. Tracks MCFC/VCFC counters with 8-bit wrap-around. |
+| `src/components/FrameConfig.tsx` | Panel for all primary-header parameters: SCID, VCID, frame length, sync flag, FHP, optional fields, and CADU encapsulation with payload dependency selection. |
 | `src/components/PayloadInput.tsx` | Hex / ASCII payload editor with file-upload, capacity bar, and helper fill buttons (idle, ramp). |
 | `src/components/TransmissionPanel.tsx` | WebSocket URL, interval control, start/stop, and live transmission statistics. |
-| `src/components/FramePreview.tsx` | Live colour-coded hex dump with section legend (ASM, Primary Header, Secondary Header, Data Field, OCF, FECF). |
+| `src/components/FramePreview.tsx` | Live colour-coded hex dump with section legend (ASM, Primary Header, Secondary Header, Data Field, OCF, FECF, RS Data, RS Check, Codeword). |
 
 ### Frame Structure
 
@@ -45,14 +46,15 @@ CADU (CCSDS 131.0-B-5), when enabled:
 
 ### Unit Tests
 
-91 tests across four test suites using **Vitest**:
+134 tests across five test suites using **Vitest**:
 
 | Suite | Tests | Coverage |
 |-------|-------|----------|
 | `crc.test.ts` | 8 | CRC-16/CCITT-FALSE algorithm with known CCITT check vector (0x29B1) |
 | `hex.test.ts` | 33 | `hexToBytes`, `bytesToHex`, `byteHex`, `asciiToBytes`, `hexDump`, `validateHexInput` |
 | `frameBuilder.test.ts` | 33 | Frame construction, header encoding, optional fields, error cases, `availableDataBytes` |
-| `cadu.test.ts` | 17 | ASM value, CADU structure, section offsetting, PRBS sequence vectors, self-inverse property |
+| `cadu.test.ts` | 27 | ASM value, CADU structure, section offsetting, PRBS sequence vectors, RS payload, codeword payload |
+| `reedSolomon.test.ts` | 33 | GF(2⁸) table correctness, generator polynomial roots, systematic encoding, syndrome validation, interleaving |
 
 ### Docker Support
 
@@ -154,7 +156,11 @@ Use the **Frame Config** panel on the left to set:
 | **FECF** | Enable to append a CRC-16/CCITT-FALSE checksum |
 | **Idle Fill Byte** | Byte value used to pad unused data field space (default `0xE0`) |
 | **Enable CADU** | Wraps the completed Transfer Frame in a CADU (prepends ASM `1A CF FC 1D`) |
-| **Pseudo-randomization** | Applies CCSDS PRBS to the Transfer Frame before transmission (visible only when CADU is enabled) |
+| **Payload Dependency** | Selects what fills the CADU payload: Transfer Frame, Reed-Solomon, or Codeword (visible only when CADU is enabled) |
+| **RS Variant** | RS(255,223) or RS(255,239) code rate (visible when Payload = Reed-Solomon) |
+| **Interleave Depth** | Number of independently encoded RS sub-blocks: 1, 2, 3, 4, 5, or 8 (visible when Payload = Reed-Solomon) |
+| **Codeword Data** | Raw hex bytes used directly as CADU payload (visible when Payload = Codeword) |
+| **Pseudo-randomization** | Applies CCSDS PRBS to the payload bytes before transmission (visible only when CADU is enabled) |
 
 The **Available Payload** counter at the bottom of the panel shows how many bytes remain for user data given the current configuration.
 
@@ -162,14 +168,49 @@ The **Available Payload** counter at the bottom of the panel shows how many byte
 
 When **Enable CADU** is toggled on in the *CADU Encapsulation* section of the Frame Config panel:
 
-- The 4-byte **Attached Synchronization Marker (ASM)** `1A CF FC 1D` is prepended to every outgoing Transfer Frame.
-- The bytes-sent counter and Frame Preview reflect the full CADU size (frame length + 4 bytes).
-- The **Pseudo-randomization (PRBS)** sub-toggle, when enabled, XORs the Transfer Frame bytes (not the ASM) with the output of a Fibonacci LFSR prior to transmission:
-  - Generator polynomial: h(x) = x⁸ + x⁷ + x⁵ + x³ + 1
-  - Initial fill: `0xFF` (all ones)
-  - Period: 255 bits
-  - This operation is self-inverse — applying PRBS twice recovers the original data.
-- The header bar shows an **CADU** badge (or **CADU+PRBS** when randomization is active).
+- The 4-byte **Attached Synchronization Marker (ASM)** `1A CF FC 1D` is prepended to every outgoing frame.
+- The bytes-sent counter and Frame Preview reflect the full CADU size.
+
+##### Payload Dependency
+
+The **Payload Dependency** dropdown selects what occupies the CADU payload (after the ASM):
+
+**1. Transfer Frame** (default)
+- CADU payload = the completed TM Transfer Frame bytes.
+- CADU size = frame length + 4 bytes.
+
+**2. Reed-Solomon**
+- The Transfer Frame data is RS-encoded using the selected code variant and interleave depth.
+- CADU payload = I×255 bytes of RS-coded data (data + check symbols, byte-interleaved when I > 1).
+- Supported variants (CCSDS 131.0-B-5 §4, GF(2⁸), primitive polynomial 0x187, FCR=112):
+
+  | Variant | Data bytes (k) | Check bytes (2t) | Error correction |
+  |---------|---------------|------------------|------------------|
+  | RS(255,223) | 223 | 32 | E=16 symbol errors |
+  | RS(255,239) | 239 | 16 | E=8 symbol errors |
+
+- **Interleave Depth (I)**: 1, 2, 3, 4, 5, or 8 independent codewords. Total payload = I×255 bytes. The Transfer Frame data is zero-padded or truncated to k×I bytes to match the RS input requirement.
+- The Frame Preview colour-codes the **RS Data** (green) and **RS Check** (pink) sections within the CADU.
+
+**3. Codeword**
+- Enter arbitrary hex bytes in the **Codeword Data** field.
+- CADU payload = the raw codeword bytes exactly as entered.
+- Useful for injecting pre-computed or externally generated channel codewords.
+
+##### Pseudo-randomization (PRBS)
+
+When enabled, the payload bytes (not the ASM) are XOR'd with the output of a Fibonacci LFSR prior to transmission:
+- Generator polynomial: h(x) = x⁸ + x⁷ + x⁵ + x³ + 1
+- Initial fill: `0xFF` (all ones)
+- Period: 255 bits
+- Self-inverse — applying PRBS twice recovers the original data.
+
+The header bar shows a badge indicating the active CADU mode:
+- **CADU** — Transfer Frame only
+- **CADU+RS(255,223)** — Reed-Solomon RS(255,223)
+- **CADU+RS(255,239)×5** — Reed-Solomon RS(255,239) with interleave depth 5
+- **CADU+CW** — Raw Codeword
+- Append **+PRBS** to any of the above when randomization is active.
 
 ### 2. Enter Payload Data
 
@@ -284,7 +325,9 @@ Postman's built-in WebSocket client lets you connect to any WebSocket server and
         ├── frameBuilder.ts
         ├── frameBuilder.test.ts
         ├── hex.ts
-        └── hex.test.ts
+        ├── hex.test.ts
+        ├── reedSolomon.ts
+        └── reedSolomon.test.ts
 ```
 
 ---

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,10 @@ const DEFAULT_FRAME_CONFIG: FrameConfig = {
   idleFillByte: 0xe0,
   hasCADU: false,
   caduRandomize: false,
+  caduPayloadType: 'transfer-frame',
+  rsVariant: 'RS_255_223',
+  rsInterleaveDepth: 1,
+  caduCodewordData: '',
 };
 
 const DEFAULT_TX_CONFIG: TransmissionConfig = {
@@ -69,11 +73,16 @@ export default function App() {
   // Wrap in CADU if enabled (preview only — the transmitter handles its own wrapping)
   const displayResult = useMemo(() => {
     if (frameConfig.hasCADU && !previewResult.error) {
-      const { cadu, sections } = buildCADU(previewResult.frame, frameConfig.caduRandomize, previewResult.sections);
+      const { cadu, sections, error } = buildCADU(
+        previewResult.frame,
+        frameConfig,
+        previewResult.sections,
+      );
+      if (error) return { frame: new Uint8Array(0), sections: [], error };
       return { frame: cadu, sections, error: null };
     }
     return previewResult;
-  }, [frameConfig.hasCADU, frameConfig.caduRandomize, previewResult]);
+  }, [frameConfig, previewResult]);
 
   // If running and we have a last transmitted frame, show that; otherwise show the built preview
   const displayFrame = lastFrame ?? displayResult.frame;
@@ -96,7 +105,17 @@ export default function App() {
           {frameConfig.hasFECF && <span className="text-red-400">FECF</span>}
           {frameConfig.hasOCF && <span className="text-amber-400">OCF</span>}
           {frameConfig.hasSecondaryHeader && <span className="text-purple-400">SH</span>}
-          {frameConfig.hasCADU && <span className="text-orange-400">CADU{frameConfig.caduRandomize && '+PRBS'}</span>}
+          {frameConfig.hasCADU && (
+            <span className="text-orange-400">
+              {'CADU'}
+              {frameConfig.caduPayloadType === 'reed-solomon' && (
+                `+${frameConfig.rsVariant === 'RS_255_223' ? 'RS(255,223)' : 'RS(255,239)'}` +
+                (frameConfig.rsInterleaveDepth > 1 ? `×${frameConfig.rsInterleaveDepth}` : '')
+              )}
+              {frameConfig.caduPayloadType === 'codeword' && '+CW'}
+              {frameConfig.caduRandomize && '+PRBS'}
+            </span>
+          )}
         </div>
       </header>
 

--- a/src/components/FrameConfig.tsx
+++ b/src/components/FrameConfig.tsx
@@ -1,5 +1,6 @@
-import type { FrameConfig } from '../types';
+import type { FrameConfig, CaduPayloadType, RsVariant, RsInterleaveDepth } from '../types';
 import { FHP_IDLE, FHP_NO_PACKET, availableDataBytes } from '../utils/frameBuilder';
+import { RS_VARIANT_INFO } from '../utils/reedSolomon';
 
 interface Props {
   config: FrameConfig;
@@ -311,8 +312,86 @@ export function FrameConfig({ config, onChange, disabled }: Props) {
                 </p>
               )}
             </div>
+
             {config.hasCADU && (
-              <div className="ml-4 space-y-2 border-l-2 border-orange-900/40 pl-3">
+              <div className="ml-4 space-y-3 border-l-2 border-orange-900/40 pl-3">
+
+                {/* Payload Dependency */}
+                <div>
+                  <label className="field-label">Payload Dependency</label>
+                  <select
+                    className="field-input"
+                    value={config.caduPayloadType}
+                    disabled={disabled}
+                    onChange={e => onChange({ caduPayloadType: e.target.value as CaduPayloadType })}
+                  >
+                    <option value="transfer-frame">Transfer Frame</option>
+                    <option value="reed-solomon">Reed-Solomon</option>
+                    <option value="codeword">Codeword</option>
+                  </select>
+                </div>
+
+                {/* Reed-Solomon sub-options */}
+                {config.caduPayloadType === 'reed-solomon' && (
+                  <div className="space-y-2">
+                    <div>
+                      <label className="field-label">RS Variant</label>
+                      <select
+                        className="field-input"
+                        value={config.rsVariant}
+                        disabled={disabled}
+                        onChange={e => onChange({ rsVariant: e.target.value as RsVariant })}
+                      >
+                        <option value="RS_255_223">RS(255,223) — k=223, 32 check bytes, E=16</option>
+                        <option value="RS_255_239">RS(255,239) — k=239, 16 check bytes, E=8</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label className="field-label">Interleave Depth</label>
+                      <select
+                        className="field-input"
+                        value={config.rsInterleaveDepth}
+                        disabled={disabled}
+                        onChange={e => onChange({ rsInterleaveDepth: parseInt(e.target.value) as RsInterleaveDepth })}
+                      >
+                        {([1, 2, 3, 4, 5, 8] as RsInterleaveDepth[]).map(d => (
+                          <option key={d} value={d}>
+                            I={d} — {RS_VARIANT_INFO[config.rsVariant].n * d}B payload
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <p className="text-xs text-slate-600">
+                      GF(2⁸) p(x)=x⁸+x⁷+x²+x+1, FCR=112, α=0x02
+                    </p>
+                    <p className="text-xs text-slate-500">
+                      Frame data padded/truncated to{' '}
+                      <span className="text-emerald-400 font-mono">
+                        {RS_VARIANT_INFO[config.rsVariant].k * config.rsInterleaveDepth}
+                      </span>
+                      {' '}bytes for RS input
+                    </p>
+                  </div>
+                )}
+
+                {/* Raw codeword input */}
+                {config.caduPayloadType === 'codeword' && (
+                  <div>
+                    <label className="field-label">Codeword Data (hex)</label>
+                    <textarea
+                      className="field-input font-mono text-teal-300 h-20 resize-none"
+                      placeholder="AA BB CC DD ..."
+                      value={config.caduCodewordData}
+                      disabled={disabled}
+                      onChange={e => onChange({ caduCodewordData: e.target.value })}
+                    />
+                    <p className="text-xs text-slate-600 mt-1">
+                      {config.caduCodewordData.replace(/[\s:]/g, '').length / 2 | 0} bytes entered
+                    </p>
+                  </div>
+                )}
+
+                {/* PRBS randomization */}
                 <Toggle
                   label="Pseudo-randomization (PRBS)"
                   checked={config.caduRandomize}

--- a/src/hooks/useTransmitter.ts
+++ b/src/hooks/useTransmitter.ts
@@ -107,9 +107,17 @@ export function useTransmitter(): UseTransmitterReturn {
             return;
           }
 
-          const frameToSend = frameConfig.hasCADU
-            ? buildCADU(result.frame, frameConfig.caduRandomize).cadu
-            : result.frame;
+          const caduResult = frameConfig.hasCADU
+            ? buildCADU(result.frame, frameConfig)
+            : null;
+
+          if (caduResult?.error) {
+            setLastError(caduResult.error);
+            stop();
+            return;
+          }
+
+          const frameToSend = caduResult ? caduResult.cadu : result.frame;
 
           try {
             ws.send(frameToSend.buffer);

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,20 @@ export interface FrameConfig {
   // CADU encapsulation (CCSDS 131.0-B-5)
   hasCADU: boolean;        // prepend 4-byte ASM (0x1A CF FC 1D)
   caduRandomize: boolean;  // apply PRBS pseudo-randomization to the Transfer Frame
+  caduPayloadType: CaduPayloadType;    // what fills the CADU payload
+  rsVariant: RsVariant;                // RS code variant (only when caduPayloadType='reed-solomon')
+  rsInterleaveDepth: RsInterleaveDepth;// RS interleave depth I (1, 2, 3, 4, 5, or 8)
+  caduCodewordData: string;            // hex string for raw codeword (only when caduPayloadType='codeword')
 }
+
+/** What bytes fill the CADU payload (after the ASM). */
+export type CaduPayloadType = 'transfer-frame' | 'reed-solomon' | 'codeword';
+
+/** CCSDS RS code variant (CCSDS 131.0-B-5 §4). */
+export type RsVariant = 'RS_255_223' | 'RS_255_239';
+
+/** RS interleave depth (number of independently encoded sub-blocks). */
+export type RsInterleaveDepth = 1 | 2 | 3 | 4 | 5 | 8;
 
 export type PayloadMode = 'hex' | 'ascii';
 

--- a/src/utils/cadu.test.ts
+++ b/src/utils/cadu.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { ASM, ASM_SIZE, buildCADU, applyPRBS } from './cadu';
+import type { CADUConfig } from './cadu';
+
+// Default config for transfer-frame tests (matches old test API)
+const TF_CONFIG: CADUConfig = {
+  caduRandomize: false,
+  caduPayloadType: 'transfer-frame',
+  rsVariant: 'RS_255_223',
+  rsInterleaveDepth: 1,
+  caduCodewordData: '',
+};
+
+const TF_CONFIG_PRBS: CADUConfig = { ...TF_CONFIG, caduRandomize: true };
 
 // ---------------------------------------------------------------------------
 // ASM constant
@@ -20,19 +32,19 @@ describe('ASM', () => {
 });
 
 // ---------------------------------------------------------------------------
-// buildCADU — structure
+// buildCADU — structure (transfer-frame payload)
 // ---------------------------------------------------------------------------
 
 describe('buildCADU – structure', () => {
   it('output length equals ASM_SIZE + frame.length', () => {
     const frame = new Uint8Array(7).fill(0x00);
-    const { cadu } = buildCADU(frame, false);
+    const { cadu } = buildCADU(frame, TF_CONFIG);
     expect(cadu.length).toBe(ASM_SIZE + 7);
   });
 
   it('first 4 bytes are always the ASM', () => {
     const frame = new Uint8Array(16).fill(0xaa);
-    const { cadu } = buildCADU(frame, false);
+    const { cadu } = buildCADU(frame, TF_CONFIG);
     expect(cadu[0]).toBe(0x1a);
     expect(cadu[1]).toBe(0xcf);
     expect(cadu[2]).toBe(0xfc);
@@ -41,7 +53,7 @@ describe('buildCADU – structure', () => {
 
   it('without randomization: frame bytes follow ASM unchanged', () => {
     const frame = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
-    const { cadu } = buildCADU(frame, false);
+    const { cadu } = buildCADU(frame, TF_CONFIG);
     expect(cadu[4]).toBe(0x01);
     expect(cadu[5]).toBe(0x02);
     expect(cadu[6]).toBe(0x03);
@@ -50,7 +62,7 @@ describe('buildCADU – structure', () => {
 
   it('with randomization: ASM bytes are still unmodified', () => {
     const frame = new Uint8Array(8).fill(0xff);
-    const { cadu } = buildCADU(frame, true);
+    const { cadu } = buildCADU(frame, TF_CONFIG_PRBS);
     expect(cadu[0]).toBe(0x1a);
     expect(cadu[1]).toBe(0xcf);
     expect(cadu[2]).toBe(0xfc);
@@ -59,21 +71,26 @@ describe('buildCADU – structure', () => {
 
   it('with randomization: frame bytes differ from original', () => {
     const frame = new Uint8Array(8).fill(0x00);
-    const { cadu } = buildCADU(frame, true);
+    const { cadu } = buildCADU(frame, TF_CONFIG_PRBS);
     // PRBS applied to all-zeros gives the PRBS mask itself — must differ from 0x00
     const frameBytes = cadu.slice(ASM_SIZE);
     const allZero = frameBytes.every(b => b === 0x00);
     expect(allZero).toBe(false);
   });
+
+  it('error is null for valid transfer-frame payload', () => {
+    const { error } = buildCADU(new Uint8Array(8), TF_CONFIG);
+    expect(error).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
-// buildCADU — sections
+// buildCADU — sections (transfer-frame)
 // ---------------------------------------------------------------------------
 
 describe('buildCADU – sections', () => {
   it('first section is the ASM, spanning bytes 0–4', () => {
-    const { sections } = buildCADU(new Uint8Array(8), false);
+    const { sections } = buildCADU(new Uint8Array(8), TF_CONFIG);
     const asm = sections[0];
     expect(asm.label).toBe('ASM');
     expect(asm.start).toBe(0);
@@ -81,7 +98,7 @@ describe('buildCADU – sections', () => {
   });
 
   it('returns only the ASM section when no frame sections are provided', () => {
-    const { sections } = buildCADU(new Uint8Array(8), false);
+    const { sections } = buildCADU(new Uint8Array(8), TF_CONFIG);
     expect(sections.length).toBe(1);
   });
 
@@ -90,7 +107,7 @@ describe('buildCADU – sections', () => {
       { label: 'Primary Header', start: 0, end: 6, color: '', textColor: '' },
       { label: 'Data Field', start: 6, end: 14, color: '', textColor: '' },
     ];
-    const { sections } = buildCADU(new Uint8Array(14), false, frameSections);
+    const { sections } = buildCADU(new Uint8Array(14), TF_CONFIG, frameSections);
     expect(sections.length).toBe(3);
     expect(sections[1].label).toBe('Primary Header');
     expect(sections[1].start).toBe(4);
@@ -105,12 +122,100 @@ describe('buildCADU – sections', () => {
       { label: 'A', start: 0, end: 6, color: '', textColor: '' },
       { label: 'B', start: 6, end: 14, color: '', textColor: '' },
     ];
-    const { sections, cadu } = buildCADU(new Uint8Array(14), false, frameSections);
+    const { sections, cadu } = buildCADU(new Uint8Array(14), TF_CONFIG, frameSections);
     expect(sections[0].start).toBe(0);
     expect(sections[sections.length - 1].end).toBe(cadu.length);
     for (let i = 1; i < sections.length; i++) {
       expect(sections[i].start).toBe(sections[i - 1].end);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCADU — Reed-Solomon payload
+// ---------------------------------------------------------------------------
+
+describe('buildCADU – Reed-Solomon payload', () => {
+  const RS_CONFIG: CADUConfig = {
+    caduRandomize: false,
+    caduPayloadType: 'reed-solomon',
+    rsVariant: 'RS_255_223',
+    rsInterleaveDepth: 1,
+    caduCodewordData: '',
+  };
+
+  it('CADU length = ASM_SIZE + 255 for RS(255,223) depth=1', () => {
+    const { cadu, error } = buildCADU(new Uint8Array(223), RS_CONFIG);
+    expect(error).toBeNull();
+    expect(cadu.length).toBe(ASM_SIZE + 255);
+  });
+
+  it('CADU length = ASM_SIZE + 510 for RS(255,223) depth=2', () => {
+    const cfg: CADUConfig = { ...RS_CONFIG, rsInterleaveDepth: 2 };
+    const { cadu } = buildCADU(new Uint8Array(446), cfg);
+    expect(cadu.length).toBe(ASM_SIZE + 510);
+  });
+
+  it('sections contain RS Data and RS Check entries', () => {
+    const { sections } = buildCADU(new Uint8Array(223), RS_CONFIG);
+    const rsData = sections.find(s => s.label.startsWith('RS Data'));
+    const rsCheck = sections.find(s => s.label.startsWith('RS Check'));
+    expect(rsData).toBeDefined();
+    expect(rsCheck).toBeDefined();
+  });
+
+  it('ASM is still first 4 bytes', () => {
+    const { cadu } = buildCADU(new Uint8Array(223), RS_CONFIG);
+    expect(cadu[0]).toBe(0x1a);
+    expect(cadu[3]).toBe(0x1d);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCADU — Codeword payload
+// ---------------------------------------------------------------------------
+
+describe('buildCADU – Codeword payload', () => {
+  it('uses raw hex bytes as CADU payload', () => {
+    const cfg: CADUConfig = {
+      caduRandomize: false,
+      caduPayloadType: 'codeword',
+      rsVariant: 'RS_255_223',
+      rsInterleaveDepth: 1,
+      caduCodewordData: 'DEADBEEF',
+    };
+    const { cadu, error } = buildCADU(new Uint8Array(0), cfg);
+    expect(error).toBeNull();
+    expect(cadu.length).toBe(ASM_SIZE + 4);
+    expect(cadu[4]).toBe(0xde);
+    expect(cadu[5]).toBe(0xad);
+    expect(cadu[6]).toBe(0xbe);
+    expect(cadu[7]).toBe(0xef);
+  });
+
+  it('returns error for invalid hex', () => {
+    const cfg: CADUConfig = {
+      caduRandomize: false,
+      caduPayloadType: 'codeword',
+      rsVariant: 'RS_255_223',
+      rsInterleaveDepth: 1,
+      caduCodewordData: 'ZZZZ',
+    };
+    const { error } = buildCADU(new Uint8Array(0), cfg);
+    expect(error).not.toBeNull();
+  });
+
+  it('empty codeword data gives CADU with only ASM', () => {
+    const cfg: CADUConfig = {
+      caduRandomize: false,
+      caduPayloadType: 'codeword',
+      rsVariant: 'RS_255_223',
+      rsInterleaveDepth: 1,
+      caduCodewordData: '',
+    };
+    const { cadu, error } = buildCADU(new Uint8Array(0), cfg);
+    expect(error).toBeNull();
+    expect(cadu.length).toBe(ASM_SIZE);
   });
 });
 

--- a/src/utils/cadu.ts
+++ b/src/utils/cadu.ts
@@ -3,19 +3,25 @@
  * Reference: CCSDS 131.0-B-5 (TM Synchronization and Channel Coding)
  *
  * CADU structure:
- *   [ASM 4 bytes] [Transfer Frame (optionally pseudo-randomized)]
+ *   [ASM 4 bytes] [Payload]
+ *
+ * Payload options (caduPayloadType):
+ *   'transfer-frame' — Transfer Frame bytes (optionally PRBS-randomized)
+ *   'reed-solomon'   — RS-encoded Transfer Frame (RS(255,223) or RS(255,239),
+ *                      with configurable interleave depth; optionally PRBS-randomized)
+ *   'codeword'       — User-supplied raw codeword bytes (hex input)
  *
  * Attached Synchronization Marker (ASM):
- *   0x1A 0xCF 0xFC 0x1D  — used for uncoded, convolutional, Reed-Solomon,
- *   concatenated, and rate-7/8 LDPC coded data (Table 2-1).
+ *   0x1A 0xCF 0xFC 0x1D  — Table 2-1, CCSDS 131.0-B-5
  *
- * Pseudo-randomization (optional, CCSDS 131.0-B-5 §9.1):
- *   Fibonacci LFSR, generator polynomial h(x) = x^8 + x^7 + x^5 + x^3 + 1,
- *   initial fill all-ones (0xFF), 255-bit period.
- *   The sequence is XOR'd with the Transfer Frame only (ASM is not randomized).
+ * Pseudo-randomization (CCSDS 131.0-B-5 §9.1):
+ *   Fibonacci LFSR, h(x) = x^8+x^7+x^5+x^3+1, seed 0xFF, 255-bit period.
+ *   Applied to the payload bytes only (ASM is never randomized).
  */
 
-import type { FrameSection } from '../types';
+import type { FrameConfig, FrameSection, CaduPayloadType, RsVariant, RsInterleaveDepth } from '../types';
+import { rsEncode, RS_VARIANT_INFO } from './reedSolomon';
+import { hexToBytes } from './hex';
 
 export const ASM = new Uint8Array([0x1a, 0xcf, 0xfc, 0x1d]);
 export const ASM_SIZE = 4;
@@ -23,23 +29,106 @@ export const ASM_SIZE = 4;
 export interface CADUResult {
   cadu: Uint8Array;
   sections: FrameSection[];
+  error: string | null;
+}
+
+export interface CADUConfig {
+  caduRandomize: boolean;
+  caduPayloadType: CaduPayloadType;
+  rsVariant: RsVariant;
+  rsInterleaveDepth: RsInterleaveDepth;
+  caduCodewordData: string;
 }
 
 /**
- * Wrap a Transfer Frame in a CADU.
+ * Assemble a CADU from a completed TM Transfer Frame.
  *
- * @param frame          - Completed TM Transfer Frame bytes.
- * @param randomize      - Apply CCSDS PRBS pseudo-randomization to the frame.
- * @param frameSections  - Section annotations from buildTMFrame (offset by ASM_SIZE).
+ * @param frame         - Completed TM Transfer Frame bytes.
+ * @param config        - CADU configuration (payload type, RS params, randomize flag).
+ * @param frameSections - Section annotations from buildTMFrame (offset by ASM_SIZE when
+ *                        payload type is 'transfer-frame').
  */
 export function buildCADU(
   frame: Uint8Array,
-  randomize: boolean,
+  config: CADUConfig,
   frameSections: FrameSection[] = [],
 ): CADUResult {
-  const cadu = new Uint8Array(ASM_SIZE + frame.length);
+  const { caduRandomize, caduPayloadType, rsVariant, rsInterleaveDepth, caduCodewordData } = config;
+
+  let payload: Uint8Array;
+  let payloadSections: FrameSection[];
+  let error: string | null = null;
+
+  // Build the payload bytes and associated sections
+  switch (caduPayloadType) {
+    case 'transfer-frame': {
+      payload = frame;
+      payloadSections = frameSections.map(s => ({
+        ...s,
+        start: s.start + ASM_SIZE,
+        end: s.end + ASM_SIZE,
+      }));
+      break;
+    }
+
+    case 'reed-solomon': {
+      const info = RS_VARIANT_INFO[rsVariant];
+      const rsPayload = rsEncode(frame, rsVariant, rsInterleaveDepth);
+      payload = rsPayload;
+
+      // Sections: one "Data" section per sub-block + one "RS Check" section per sub-block
+      // For depth > 1 the data is interleaved so we just annotate the full RS block.
+      const I = rsInterleaveDepth;
+      const rsDataBytes = info.k * I;    // data portion of RS payload
+      const rsSections: FrameSection[] = [
+        {
+          label: `RS Data (${I === 1 ? info.k : `${info.k}×${I}`}B)`,
+          start: ASM_SIZE,
+          end: ASM_SIZE + rsDataBytes,
+          color: 'bg-green-900/60',
+          textColor: 'text-green-300',
+        },
+        {
+          label: `RS Check (${info.twoT * I}B)`,
+          start: ASM_SIZE + rsDataBytes,
+          end: ASM_SIZE + rsPayload.length,
+          color: 'bg-pink-900/60',
+          textColor: 'text-pink-300',
+        },
+      ];
+      payloadSections = rsSections;
+      break;
+    }
+
+    case 'codeword': {
+      const parsed = caduCodewordData.trim() ? hexToBytes(caduCodewordData) : new Uint8Array(0);
+      if (parsed === null) {
+        error = 'Codeword: invalid hex data';
+        payload = new Uint8Array(0);
+      } else {
+        payload = parsed;
+      }
+      payloadSections = payload.length > 0
+        ? [{
+            label: 'Codeword',
+            start: ASM_SIZE,
+            end: ASM_SIZE + payload.length,
+            color: 'bg-teal-900/60',
+            textColor: 'text-teal-300',
+          }]
+        : [];
+      break;
+    }
+  }
+
+  if (error) {
+    return { cadu: new Uint8Array(0), sections: [], error };
+  }
+
+  const processedPayload = caduRandomize ? applyPRBS(payload) : payload;
+  const cadu = new Uint8Array(ASM_SIZE + processedPayload.length);
   cadu.set(ASM, 0);
-  cadu.set(randomize ? applyPRBS(frame) : frame, ASM_SIZE);
+  cadu.set(processedPayload, ASM_SIZE);
 
   const sections: FrameSection[] = [
     {
@@ -49,14 +138,10 @@ export function buildCADU(
       color: 'bg-orange-900/60',
       textColor: 'text-orange-300',
     },
-    ...frameSections.map(s => ({
-      ...s,
-      start: s.start + ASM_SIZE,
-      end: s.end + ASM_SIZE,
-    })),
+    ...payloadSections,
   ];
 
-  return { cadu, sections };
+  return { cadu, sections, error: null };
 }
 
 /**

--- a/src/utils/frameBuilder.test.ts
+++ b/src/utils/frameBuilder.test.ts
@@ -24,6 +24,10 @@ function makeConfig(overrides: Partial<FrameConfig> = {}): FrameConfig {
     idleFillByte: 0xe0,
     hasCADU: false,
     caduRandomize: false,
+    caduPayloadType: 'transfer-frame',
+    rsVariant: 'RS_255_223',
+    rsInterleaveDepth: 1,
+    caduCodewordData: '',
     ...overrides,
   };
 }

--- a/src/utils/reedSolomon.test.ts
+++ b/src/utils/reedSolomon.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest';
+import {
+  rsEncodeBlock,
+  rsEncode,
+  rsIsValidCodeword,
+  buildGenPoly,
+  gfEvalPoly,
+  gfMul,
+  GF_EXP,
+  GF_LOG,
+  RS_VARIANT_INFO,
+} from './reedSolomon';
+
+// ---------------------------------------------------------------------------
+// GF(2^8) table correctness
+// ---------------------------------------------------------------------------
+
+describe('GF(2^8) tables', () => {
+  it('GF_EXP[0] = 1 (α^0 = 1)', () => {
+    expect(GF_EXP[0]).toBe(1);
+  });
+
+  it('GF_EXP[1] = 2 (primitive element α = 0x02)', () => {
+    expect(GF_EXP[1]).toBe(2);
+  });
+
+  it('GF_EXP[254] is non-zero (all 255 elements are non-zero)', () => {
+    for (let i = 0; i < 255; i++) {
+      expect(GF_EXP[i]).not.toBe(0);
+    }
+  });
+
+  it('GF_EXP[255] = GF_EXP[0] = 1 (period 255)', () => {
+    expect(GF_EXP[255]).toBe(GF_EXP[0]);
+  });
+
+  it('GF_LOG[GF_EXP[i]] = i for i in 0..254', () => {
+    for (let i = 0; i < 255; i++) {
+      expect(GF_LOG[GF_EXP[i]]).toBe(i);
+    }
+  });
+
+  it('all 255 non-zero elements appear in GF_EXP[0..254] (field is cyclic)', () => {
+    const seen = new Set<number>();
+    for (let i = 0; i < 255; i++) seen.add(GF_EXP[i]);
+    expect(seen.size).toBe(255);
+    expect(seen.has(0)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Generator polynomial
+// ---------------------------------------------------------------------------
+
+describe('buildGenPoly', () => {
+  it('RS(255,223): generator has degree 32 (33 coefficients)', () => {
+    const gen = buildGenPoly(32, 112);
+    expect(gen.length).toBe(33);
+  });
+
+  it('RS(255,239): generator has degree 16 (17 coefficients)', () => {
+    const gen = buildGenPoly(16, 112);
+    expect(gen.length).toBe(17);
+  });
+
+  it('leading coefficient is 1 (monic polynomial)', () => {
+    const gen32 = buildGenPoly(32, 112);
+    const gen16 = buildGenPoly(16, 112);
+    expect(gen32[32]).toBe(1);
+    expect(gen16[16]).toBe(1);
+  });
+
+  it('constant term (gen[0]) is non-zero (no zero root at x=0)', () => {
+    expect(buildGenPoly(32, 112)[0]).not.toBe(0);
+    expect(buildGenPoly(16, 112)[0]).not.toBe(0);
+  });
+
+  it('generator has all FCR+j as roots for j=0..2t-1', () => {
+    // buildGenPoly stores coefficients in ascending order: gen[i] = coeff of x^i
+    // Evaluate using Horner's in ascending order: acc = gen[deg]; for i=deg-1..0: acc=acc*x ^ gen[i]
+    function evalAscending(coeffs: Uint8Array, x: number): number {
+      let acc = 0;
+      for (let i = coeffs.length - 1; i >= 0; i--) {
+        acc = gfMul(acc, x) ^ coeffs[i];
+      }
+      return acc;
+    }
+    const twoT = 16;
+    const fcr = 112;
+    const gen = buildGenPoly(twoT, fcr);
+    for (let j = 0; j < twoT; j++) {
+      const root = GF_EXP[(fcr + j) % 255];
+      expect(evalAscending(gen, root)).toBe(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rsEncodeBlock
+// ---------------------------------------------------------------------------
+
+describe('rsEncodeBlock', () => {
+  it('RS(255,223): output length is 255', () => {
+    const data = new Uint8Array(223);
+    expect(rsEncodeBlock(data, 'RS_255_223').length).toBe(255);
+  });
+
+  it('RS(255,239): output length is 255', () => {
+    const data = new Uint8Array(239);
+    expect(rsEncodeBlock(data, 'RS_255_239').length).toBe(255);
+  });
+
+  it('first k bytes of output equal the input data (systematic code)', () => {
+    const data = new Uint8Array(223).map((_, i) => (i * 37 + 5) & 0xff);
+    const codeword = rsEncodeBlock(data, 'RS_255_223');
+    for (let i = 0; i < 223; i++) {
+      expect(codeword[i]).toBe(data[i]);
+    }
+  });
+
+  it('all-zeros data yields all-zero check symbols', () => {
+    const data = new Uint8Array(223); // all zeros
+    const codeword = rsEncodeBlock(data, 'RS_255_223');
+    for (let i = 223; i < 255; i++) {
+      expect(codeword[i]).toBe(0);
+    }
+  });
+
+  it('all-zeros data RS(255,239) yields all-zero check symbols', () => {
+    const data = new Uint8Array(239);
+    const codeword = rsEncodeBlock(data, 'RS_255_239');
+    for (let i = 239; i < 255; i++) {
+      expect(codeword[i]).toBe(0);
+    }
+  });
+
+  it('non-zero data produces non-zero check symbols (encoding is active)', () => {
+    const data = new Uint8Array(223).fill(0x01);
+    const codeword = rsEncodeBlock(data, 'RS_255_223');
+    const checkBytes = codeword.slice(223);
+    const allZero = Array.from(checkBytes).every(b => b === 0);
+    expect(allZero).toBe(false);
+  });
+
+  it('different data produces different check symbols', () => {
+    const data1 = new Uint8Array(223).fill(0xaa);
+    const data2 = new Uint8Array(223).fill(0x55);
+    const cw1 = rsEncodeBlock(data1, 'RS_255_223').slice(223);
+    const cw2 = rsEncodeBlock(data2, 'RS_255_223').slice(223);
+    expect(cw1).not.toEqual(cw2);
+  });
+
+  it('throws when data length is wrong', () => {
+    expect(() => rsEncodeBlock(new Uint8Array(100), 'RS_255_223')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Syndrome validation (rsIsValidCodeword)
+// ---------------------------------------------------------------------------
+
+describe('rsIsValidCodeword', () => {
+  it('a freshly encoded RS(255,223) codeword passes validation', () => {
+    const data = new Uint8Array(223).map((_, i) => (i * 13 + 7) & 0xff);
+    const codeword = rsEncodeBlock(data, 'RS_255_223');
+    expect(rsIsValidCodeword(codeword, 'RS_255_223')).toBe(true);
+  });
+
+  it('a freshly encoded RS(255,239) codeword passes validation', () => {
+    const data = new Uint8Array(239).map((_, i) => (i * 31 + 11) & 0xff);
+    const codeword = rsEncodeBlock(data, 'RS_255_239');
+    expect(rsIsValidCodeword(codeword, 'RS_255_239')).toBe(true);
+  });
+
+  it('all-zeros RS(255,223) codeword is valid', () => {
+    expect(rsIsValidCodeword(new Uint8Array(255), 'RS_255_223')).toBe(true);
+  });
+
+  it('all-zeros RS(255,239) codeword is valid', () => {
+    expect(rsIsValidCodeword(new Uint8Array(255), 'RS_255_239')).toBe(true);
+  });
+
+  it('flipping one byte in the data field makes the codeword invalid', () => {
+    const data = new Uint8Array(223).fill(0x42);
+    const codeword = rsEncodeBlock(data, 'RS_255_223');
+    const corrupted = new Uint8Array(codeword);
+    corrupted[10] ^= 0xff; // flip all bits in byte 10
+    expect(rsIsValidCodeword(corrupted, 'RS_255_223')).toBe(false);
+  });
+
+  it('flipping one check byte makes the codeword invalid', () => {
+    const data = new Uint8Array(239).fill(0x33);
+    const codeword = rsEncodeBlock(data, 'RS_255_239');
+    const corrupted = new Uint8Array(codeword);
+    corrupted[240] ^= 0x01;
+    expect(rsIsValidCodeword(corrupted, 'RS_255_239')).toBe(false);
+  });
+
+  it('returns false for wrong-length input', () => {
+    expect(rsIsValidCodeword(new Uint8Array(100), 'RS_255_223')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rsEncode (interleaved)
+// ---------------------------------------------------------------------------
+
+describe('rsEncode', () => {
+  it('depth=1: output length is 255', () => {
+    expect(rsEncode(new Uint8Array(223), 'RS_255_223', 1).length).toBe(255);
+  });
+
+  it('depth=1: result equals rsEncodeBlock output', () => {
+    const data = new Uint8Array(223).map((_, i) => i & 0xff);
+    expect(rsEncode(data, 'RS_255_223', 1)).toEqual(rsEncodeBlock(data, 'RS_255_223'));
+  });
+
+  it('depth=2: output length is 510 (2×255)', () => {
+    expect(rsEncode(new Uint8Array(446), 'RS_255_223', 2).length).toBe(510);
+  });
+
+  it('depth=5: output length is 1275 (5×255)', () => {
+    expect(rsEncode(new Uint8Array(1115), 'RS_255_223', 5).length).toBe(1275);
+  });
+
+  it('depth=8: output length is 2040 (8×255)', () => {
+    expect(rsEncode(new Uint8Array(1784), 'RS_255_223', 8).length).toBe(2040);
+  });
+
+  it('RS(255,239) depth=4: output length is 1020', () => {
+    expect(rsEncode(new Uint8Array(956), 'RS_255_239', 4).length).toBe(1020);
+  });
+
+  it('short input is zero-padded to k*depth', () => {
+    // Providing only 10 bytes for RS(255,223) with depth=1 — pads to 223
+    const result = rsEncode(new Uint8Array([0x01, 0x02]), 'RS_255_223', 1);
+    expect(result.length).toBe(255);
+    // The first two data bytes should match input
+    expect(result[0]).toBe(0x01);
+    expect(result[1]).toBe(0x02);
+  });
+
+  it('depth=2 interleave: first two bytes come from different codewords', () => {
+    // With all-zeros data, all codewords are all-zeros, so this tests the structure
+    const data = new Uint8Array(446); // 2*223
+    data[0] = 0xaa; // First byte of sub-block 0
+    data[223] = 0xbb; // First byte of sub-block 1
+
+    const result = rsEncode(data, 'RS_255_223', 2);
+    // Interleaved: result[0] = codeword_0[0], result[1] = codeword_1[0]
+    expect(result[0]).toBe(0xaa); // Sub-block 0, byte 0
+    expect(result[1]).toBe(0xbb); // Sub-block 1, byte 0
+  });
+
+  it('RS_VARIANT_INFO matches encoder behaviour', () => {
+    const info223 = RS_VARIANT_INFO['RS_255_223'];
+    expect(info223.n).toBe(255);
+    expect(info223.k).toBe(223);
+    expect(info223.twoT).toBe(32);
+    expect(info223.fcr).toBe(112);
+
+    const info239 = RS_VARIANT_INFO['RS_255_239'];
+    expect(info239.n).toBe(255);
+    expect(info239.k).toBe(239);
+    expect(info239.twoT).toBe(16);
+    expect(info239.fcr).toBe(112);
+  });
+});

--- a/src/utils/reedSolomon.ts
+++ b/src/utils/reedSolomon.ts
@@ -1,0 +1,210 @@
+/**
+ * Reed-Solomon encoder for CCSDS TM Synchronization and Channel Coding.
+ * Reference: CCSDS 131.0-B-5, Section 4 (RS Coding)
+ *
+ * GF(2^8) field:
+ *   Primitive polynomial: x^8 + x^7 + x^2 + x + 1  (0x187)
+ *   Primitive element:    α = 0x02  (root of the polynomial)
+ *
+ * Supported codes:
+ *   RS(255,223): k=223 data bytes, 32 check bytes, E=16 (corrects up to 16 errors)
+ *   RS(255,239): k=239 data bytes, 16 check bytes, E=8  (corrects up to 8 errors)
+ *
+ * Generator polynomial: g(x) = Π_{j=0}^{2t-1} (x + α^(FCR+j)), FCR=112
+ *
+ * Interleaving (CCSDS 131.0-B-5 §4.4):
+ *   Depth I: I independent RS codewords encoded from I sub-blocks of k bytes.
+ *   Interleaved output: byte-wise interleave of the I codewords.
+ *   Output size = n * I bytes.
+ */
+
+export type RsVariant = 'RS_255_223' | 'RS_255_239';
+export type RsInterleaveDepth = 1 | 2 | 3 | 4 | 5 | 8;
+
+export interface RsVariantInfo {
+  n: number;    // codeword length (255)
+  k: number;    // data length
+  twoT: number; // number of check symbols (n - k)
+  fcr: number;  // first consecutive root (112)
+  label: string;
+}
+
+export const RS_VARIANT_INFO: Record<RsVariant, RsVariantInfo> = {
+  RS_255_223: { n: 255, k: 223, twoT: 32, fcr: 112, label: 'RS(255,223) E=16' },
+  RS_255_239: { n: 255, k: 239, twoT: 16, fcr: 112, label: 'RS(255,239) E=8' },
+};
+
+// ---------------------------------------------------------------------------
+// GF(2^8) tables
+// ---------------------------------------------------------------------------
+
+const PRIM_POLY = 0x187; // x^8 + x^7 + x^2 + x + 1
+
+export const GF_EXP = new Uint8Array(512); // gfExp[i] = α^i; extended to 512 for convenience
+export const GF_LOG = new Uint8Array(256); // gfLog[v] = log_α(v); gfLog[0] is unused
+
+{
+  let x = 1;
+  for (let i = 0; i < 255; i++) {
+    GF_EXP[i] = x;
+    GF_LOG[x] = i;
+    x <<= 1;
+    if (x & 0x100) x ^= PRIM_POLY;
+  }
+  for (let i = 255; i < 512; i++) {
+    GF_EXP[i] = GF_EXP[i - 255];
+  }
+}
+
+export function gfMul(a: number, b: number): number {
+  if (a === 0 || b === 0) return 0;
+  return GF_EXP[(GF_LOG[a] + GF_LOG[b]) % 255];
+}
+
+// ---------------------------------------------------------------------------
+// Generator polynomial cache
+// ---------------------------------------------------------------------------
+
+const GEN_POLY_CACHE = new Map<string, Uint8Array>();
+
+/**
+ * Build the RS generator polynomial.
+ * g(x) = Π_{j=0}^{2t-1} (x + α^(fcr+j))
+ * Returns array of 2t+1 coefficients where result[i] = coeff of x^i, result[2t] = 1.
+ */
+export function buildGenPoly(twoT: number, fcr: number): Uint8Array {
+  const key = `${twoT}:${fcr}`;
+  const cached = GEN_POLY_CACHE.get(key);
+  if (cached) return cached;
+
+  let g: number[] = [1]; // start: g(x) = 1
+  for (let j = 0; j < twoT; j++) {
+    const root = GF_EXP[(fcr + j) % 255]; // α^(fcr+j)
+    // Multiply g(x) by (x + root)
+    const newG = new Array(g.length + 1).fill(0);
+    for (let i = 0; i < g.length; i++) {
+      newG[i] ^= gfMul(g[i], root); // g[i]*root → x^i term
+      newG[i + 1] ^= g[i];           // g[i] → x^(i+1) term
+    }
+    g = newG;
+  }
+
+  const result = new Uint8Array(g);
+  GEN_POLY_CACHE.set(key, result);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// RS block encoder
+// ---------------------------------------------------------------------------
+
+/**
+ * RS-encode a single k-byte data block using LFSR division.
+ * Returns n = k + 2t bytes (data bytes followed by check bytes, high-degree first).
+ */
+export function rsEncodeBlock(data: Uint8Array, variant: RsVariant): Uint8Array {
+  const { k, n, twoT, fcr } = RS_VARIANT_INFO[variant];
+  if (data.length !== k) {
+    throw new RangeError(`rsEncodeBlock: expected ${k} data bytes, got ${data.length}`);
+  }
+
+  // gen[0..twoT] where gen[2t]=1; we only use gen[0..twoT-1] for the LFSR feedback
+  const gen = buildGenPoly(twoT, fcr);
+
+  // LFSR shift register: rem[j] holds coefficient of x^j in the partial remainder
+  const rem = new Uint8Array(twoT);
+
+  for (let i = 0; i < k; i++) {
+    // feedback = current data byte XOR high-order remainder coefficient
+    const feedback = data[i] ^ rem[twoT - 1];
+    // Shift register right (higher degree to lower), adding feedback × generator coefficients
+    for (let j = twoT - 1; j > 0; j--) {
+      rem[j] = rem[j - 1] ^ gfMul(gen[j], feedback);
+    }
+    rem[0] = gfMul(gen[0], feedback);
+  }
+
+  // Codeword = [data bytes][check bytes from degree 2t-1 down to 0 (big-endian)]
+  const codeword = new Uint8Array(n);
+  codeword.set(data);
+  for (let i = 0; i < twoT; i++) {
+    codeword[k + i] = rem[twoT - 1 - i];
+  }
+  return codeword;
+}
+
+// ---------------------------------------------------------------------------
+// Interleaved RS encoder
+// ---------------------------------------------------------------------------
+
+/**
+ * RS-encode with optional interleaving.
+ *
+ * The input data is padded with 0x00 or truncated to k*depth bytes, then split
+ * into `depth` blocks of k bytes. Each block is RS-encoded to n=255 bytes.
+ * The resulting depth codewords are byte-interleaved per CCSDS 131.0-B-5 §4.4:
+ *
+ *   output[j*depth + i] = codeword_i[j]   for j=0..n-1, i=0..depth-1
+ *
+ * Output length = n * depth bytes.
+ */
+export function rsEncode(
+  data: Uint8Array,
+  variant: RsVariant,
+  interleaveDepth: RsInterleaveDepth = 1,
+): Uint8Array {
+  const { k, n } = RS_VARIANT_INFO[variant];
+  const I = interleaveDepth;
+  const totalDataBytes = k * I;
+
+  // Pad or truncate to k*I bytes
+  const paddedData = new Uint8Array(totalDataBytes);
+  paddedData.set(data.subarray(0, Math.min(data.length, totalDataBytes)));
+
+  // Encode each sub-block independently
+  const codewords: Uint8Array[] = [];
+  for (let i = 0; i < I; i++) {
+    const block = paddedData.subarray(i * k, (i + 1) * k);
+    codewords.push(rsEncodeBlock(block, variant));
+  }
+
+  if (I === 1) return codewords[0];
+
+  // Byte-interleave: output[j*I + i] = codewords[i][j]
+  const output = new Uint8Array(n * I);
+  for (let j = 0; j < n; j++) {
+    for (let i = 0; i < I; i++) {
+      output[j * I + i] = codewords[i][j];
+    }
+  }
+  return output;
+}
+
+// ---------------------------------------------------------------------------
+// Syndrome evaluation (used for validation / testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate a polynomial at a GF(2^8) point using Horner's method.
+ * `poly` is in big-endian byte order (poly[0] = coefficient of highest degree).
+ */
+export function gfEvalPoly(poly: Uint8Array, x: number): number {
+  let acc = 0;
+  for (let i = 0; i < poly.length; i++) {
+    acc = gfMul(acc, x) ^ poly[i];
+  }
+  return acc;
+}
+
+/**
+ * Check that a codeword is valid by evaluating the syndrome at the 2t roots.
+ * Returns true iff the codeword is a valid RS codeword (syndrome = 0 for all roots).
+ */
+export function rsIsValidCodeword(codeword: Uint8Array, variant: RsVariant): boolean {
+  const { n, twoT, fcr } = RS_VARIANT_INFO[variant];
+  if (codeword.length !== n) return false;
+  for (let j = 0; j < twoT; j++) {
+    if (gfEvalPoly(codeword, GF_EXP[(fcr + j) % 255]) !== 0) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
…omon, Codeword)

Extends the CADU encapsulation feature with three selectable payload types:

1. Transfer Frame (default) — unchanged behaviour: CADU = ASM + Transfer Frame
2. Reed-Solomon — RS-encodes the Transfer Frame per CCSDS 131.0-B-5 §4:
   - Supports RS(255,223) (32 check bytes, E=16) and RS(255,239) (16 check bytes, E=8)
   - Configurable interleave depth: 1, 2, 3, 4, 5, or 8 independent codewords
   - GF(2^8) with primitive polynomial 0x187, FCR=112, systematic encoding
   - Frame data is zero-padded or truncated to k×I bytes as required
   - Frame Preview colour-codes RS Data (green) and RS Check (pink) sections
3. Codeword — user-supplied raw hex bytes used directly as the CADU payload

New files:
  src/utils/reedSolomon.ts   — GF(2^8) tables, generator polynomial, LFSR encoder,
                               syndrome validation, interleaved encoding
  src/utils/reedSolomon.test.ts — 33 tests (GF tables, gen poly roots, systematic
                               encoding, syndrome, interleaving)

Updated files:
  src/types.ts               — CaduPayloadType, RsVariant, RsInterleaveDepth types;
                               new FrameConfig fields
  src/utils/cadu.ts          — buildCADU now accepts a CADUConfig object and branches
                               on caduPayloadType
  src/utils/cadu.test.ts     — updated for new buildCADU API; added RS and codeword tests
  src/components/FrameConfig.tsx — payload dependency selector, RS variant/depth controls,
                               codeword hex textarea
  src/App.tsx                — updated defaults, CADU preview, header badge
  src/hooks/useTransmitter.ts — updated to use new buildCADU signature
  src/utils/frameBuilder.test.ts — makeConfig helper updated with new FrameConfig fields
  README.md                  — documented RS encoding, interleaving, codeword payload

Total: 134 tests passing (43 new tests across reedSolomon.test.ts and cadu.test.ts).

https://claude.ai/code/session_017XTD7sTB1Ajzf4AyvpFuQ6