### PR TITLE
fix: remove unused imports that broke Docker tsc -b build

### DIFF
--- a/src/utils/cadu.ts
+++ b/src/utils/cadu.ts
@@ -19,7 +19,7 @@
  *   Applied to the payload bytes only (ASM is never randomized).
  */
 
-import type { FrameConfig, FrameSection, CaduPayloadType, RsVariant, RsInterleaveDepth } from '../types';
+import type { FrameSection, CaduPayloadType, RsVariant, RsInterleaveDepth } from '../types';
 import { rsEncode, RS_VARIANT_INFO } from './reedSolomon';
 import { hexToBytes } from './hex';
 

--- a/src/utils/reedSolomon.test.ts
+++ b/src/utils/reedSolomon.test.ts
@@ -4,7 +4,6 @@ import {
   rsEncode,
   rsIsValidCodeword,
   buildGenPoly,
-  gfEvalPoly,
   gfMul,
   GF_EXP,
   GF_LOG,


### PR DESCRIPTION
- cadu.ts: remove unused FrameConfig type import (replaced by CADUConfig interface)
- reedSolomon.test.ts: remove unused gfEvalPoly import

https://claude.ai/code/session_017XTD7sTB1Ajzf4AyvpFuQ6